### PR TITLE
refactor: fetchPost getStaticProps 적용

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+BASE_URL=http://localhost:3000

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+BASE_URL=https://harim-log.vercel.app

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# local env files
-.env*.local
+# env
+.env*
 
 # vercel
 .vercel

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,8 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env
-.env*
+# local env files
+.env*.local
 
 # vercel
 .vercel

--- a/pages/api/posts.ts
+++ b/pages/api/posts.ts
@@ -2,21 +2,25 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 
 import { POST_GROUP_COUNT } from '@/application/post/constant'
 import { getPosts } from '@/domain/post'
-import Post, { Category } from '@/domain/post/type'
+import { BriefPost, Category } from '@/domain/post/type'
 
 export default function handler(
   req: NextApiRequest,
-  res: NextApiResponse<Post[] | string>
+  res: NextApiResponse<BriefPost[] | string>
 ) {
   const query = req.query
   const { page, category } = query
 
-  res
-    .status(200)
-    .send(
-      getPosts(category as Category).slice(
-        0,
-        (Number(page as string) || 0) * POST_GROUP_COUNT
+  if (typeof page !== 'number') {
+    res.status(200).send(getPosts(category as Category))
+  } else {
+    res
+      .status(200)
+      .send(
+        getPosts(category as Category).slice(
+          0,
+          (Number(page) || 0) * POST_GROUP_COUNT
+        )
       )
-    )
+  }
 }

--- a/pages/category/[slug].tsx
+++ b/pages/category/[slug].tsx
@@ -13,14 +13,16 @@ import { CATEGORIES } from '@/domain/post/constant'
 import { NextPageWithLayout } from 'pages/_app'
 import { CardListFrame } from '@/styles/mixin'
 
-import usePagination from '@/hooks/usePagination'
+// import usePagination from '@/hooks/usePagination'
 import CategoryFilter from '@/components/post/CategoryFilter'
 import PostCardLink from '@/components/post/PostCardLink'
+import { fetchPosts } from '@/services/api'
 
 const PostsPage: NextPageWithLayout<
   InferGetStaticPropsType<typeof getStaticProps>
-> = ({ category }) => {
-  const { posts, targetRef } = usePagination({ category })
+> = ({ posts }) => {
+  // TODO:
+  // const { posts, targetRef } = usePagination({ category })
 
   return (
     <>
@@ -30,7 +32,7 @@ const PostsPage: NextPageWithLayout<
           return <PostCardLink key={slug} data={data} slug={slug} />
         })}
       </CardList>
-      <div ref={targetRef} />
+      {/* <div ref={targetRef} /> */}
     </>
   )
 }
@@ -52,10 +54,11 @@ export const getStaticProps = async (
   context: GetStaticPropsContext<ParsedUrlQuery, PreviewData>
 ) => {
   const { slug } = context.params as Params
+  const posts = await fetchPosts(process.env.BASE_URL || '', { category: slug })
 
   return {
     props: {
-      category: slug,
+      posts,
     },
   }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,14 +1,20 @@
+import { InferGetStaticPropsType } from 'next'
 import styled from 'styled-components'
 
 import { CardListFrame } from '@/styles/mixin'
+import { NextPageWithLayout } from './_app'
+import { fetchPosts } from '@/services/api'
 
-import usePagination from '@/hooks/usePagination'
+// import usePagination from '@/hooks/usePagination'
 import PostCardLink from '@/components/post/PostCardLink'
 import Layout from '@/components/layout/Layout'
 import CategoryFilter from '@/components/post/CategoryFilter'
 
-const Home = () => {
-  const { posts, targetRef } = usePagination({ category: 'all' })
+const Home: NextPageWithLayout<
+  InferGetStaticPropsType<typeof getStaticProps>
+> = ({ posts }) => {
+  // TODO:
+  // const { posts, targetRef } = usePagination({ category: 'all' })
 
   return (
     <>
@@ -18,12 +24,24 @@ const Home = () => {
           <PostCardLink key={slug} data={data} slug={slug} />
         ))}
       </CardList>
-      <div ref={targetRef} />
+      {/* <div ref={targetRef} /> */}
     </>
   )
 }
 
 export default Home
+
+export async function getStaticProps() {
+  const posts = await fetchPosts(process.env.BASE_URL || '', {
+    category: 'all',
+  })
+
+  return {
+    props: {
+      posts,
+    },
+  }
+}
 
 Home.getLayout = function getLayout(page: React.ReactElement) {
   return <Layout title="홈">{page}</Layout>

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -81,7 +81,7 @@ export const getStaticProps = async (
   const { data, content } = getPost({
     category: getCategoryOfFile(slug),
     fileTitle: slug,
-  })
+  }) as Post
 
   const mdxSource = await serialize(content)
 

--- a/src/domain/post/type.ts
+++ b/src/domain/post/type.ts
@@ -8,6 +8,8 @@ type Post = {
 
 export default Post
 
+export type BriefPost = Pick<Post, 'data' | 'slug'>
+
 export type FrontMatter = {
   title: Title
   description: Description

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -30,7 +30,7 @@ const usePagination = ({ category }: Params) => {
   useEffect(() => {
     if (!pageOffset) return
 
-    fetchPosts(pageOffset, category).then((res) => setPosts(res))
+    fetchPosts('', { pageOffset, category }).then((res) => setPosts(res))
   }, [pageOffset, category])
 
   return { posts, targetRef }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,10 +1,20 @@
 import Post, { Category } from '@/domain/post/type'
 
+type FetchPostsParams = {
+  pageOffset?: number
+  category: Category
+}
 export const fetchPosts = async (
-  pageOffset: number,
-  category: Category = 'all'
+  baseUrl: string,
+  { pageOffset, category }: FetchPostsParams
 ): Promise<Post[]> => {
-  const res = await fetch(`/api/posts?page=${pageOffset}&category=${category}`)
+  let params = [`category=${category}`]
+
+  if (typeof pageOffset === 'number') {
+    params = [...params, `page=${pageOffset}`]
+  }
+
+  const res = await fetch(`${baseUrl}/api/posts?${params.join('&')}`)
 
   return await res.json()
 }


### PR DESCRIPTION
## 주요 변경점

- infinite scroll 제거
- fetchPost getStaticProps 적용

## 특이 사항

- 블로그 포스팅 글 fetch 방식을 client side에서 getStaticProps 함수를 사용하는 방법으로 변경함에 따라 무한 스크롤 제거
